### PR TITLE
setStyleRule not in Redactor API version 10

### DIFF
--- a/resources/styles.js
+++ b/resources/styles.js
@@ -46,7 +46,7 @@ RedactorPlugins.styles = function () {
 				// add inline wrapper
 				this.inline.format(s.wrap ? s.wrap : 'span');
 				if (s.spanClass) this.inline.toggleClass(s.spanClass);
-				if (s.style) this.inline.setStyleRule(s.style);
+				if (s.style) this.inline.toggleStyle(s.style);
 			}
 			
 		},


### PR DESCRIPTION
setStyleRule not in Redactor API version 10. Changed method to toggleStyle, per changes here: http://imperavi.com/redactor/docs/whats-new-10/
